### PR TITLE
Remove '$' from argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then put `<markdown-preview>` component to your `~/.config/nyaovim/nyaovimrc.htm
 </style>
 
 <div class="horizontal">
-  <neovim-editor id="nyaovim-editor" argv$="[[argv]]"></neovim-editor>
+  <neovim-editor id="nyaovim-editor" argv="[[argv]]"></neovim-editor>
   <!-- Put component -->
   <markdown-preview editor="[[editor]]"></markdown-preview>
 </div>


### PR DESCRIPTION
The extra '$' causes the component to not work correctly (If copied from the example). Further, it makes plugin functions appear to be undefined - very confusing to track down!